### PR TITLE
Add a single test to allow making builds

### DIFF
--- a/__tests__/imperative.test.ts
+++ b/__tests__/imperative.test.ts
@@ -1,0 +1,13 @@
+describe("imperative config", () => {
+
+    // Will fail if imperative config object is changed. This is a sanity/protection check to ensure that any
+    // changes to the configuration document are intended.
+    it("config should match expected values", () => {
+        const config = require("../src/imperative");
+        expect(config.name).toBe("zos-restart-jobs");
+        expect(config.pluginSummary).toBe("Zowe CLI restart z/OS jobs plug-in");
+        expect(config.productDisplayName).toBe("Zowe CLI z/OS Jobs Restart Plug-in");
+        expect(config.rootCommandDescription).toBe("Plugin, which allows to restart z/OS jobs");
+    });
+
+});

--- a/src/imperative.ts
+++ b/src/imperative.ts
@@ -1,9 +1,8 @@
-import {IImperativeConfig} from "@zowe/imperative";
+import { IImperativeConfig } from "@zowe/imperative";
 
 const config: IImperativeConfig = {
     commandModuleGlobs: ["**/cli/*/*.definition!(.d).*s"],
     pluginSummary: "Zowe CLI restart z/OS jobs plug-in",
-    pluginAliases: ["restart-jobs"],
     rootCommandDescription: "Plugin, which allows to restart z/OS jobs",
     productDisplayName: "Zowe CLI z/OS Jobs Restart Plug-in",
     name: "zos-restart-jobs"


### PR DESCRIPTION
Add a first test to make `npm run build` working properly. The first test will be to check Imperative config for a plug-in (as it was defined in `zowe-cli-sample-plugin` repo).