### PR TITLE
Add Restart Jobs programmatic API

### DIFF
--- a/src/api/RestartJobs.ts
+++ b/src/api/RestartJobs.ts
@@ -1,4 +1,4 @@
-import { IJob, GetJobs, SubmitJobs } from "@zowe/cli";
+import { IJob, GetJobs, SubmitJobs, JOB_STATUS } from "@zowe/cli";
 import { AbstractSession, ImperativeError, ImperativeExpect } from "@zowe/imperative";
 
 export class RestartJobs {
@@ -66,6 +66,8 @@ export class RestartJobs {
         // Get the job details
         const job: IJob = await GetJobs.getJob(session, jobid);
 
+        ImperativeExpect.toBeEqual(job.status, JOB_STATUS.OUTPUT,
+                                      errorMessagePrefix + "Job status is ACTIVE, OUTPUT is required");
         ImperativeExpect.toNotBeEqual(job.retcode, "CC 0000",
                                       errorMessagePrefix + "Job status is successful, failed is required");
 

--- a/src/api/RestartJobs.ts
+++ b/src/api/RestartJobs.ts
@@ -1,5 +1,5 @@
 import { IJob, GetJobs, SubmitJobs } from "@zowe/cli";
-import { AbstractSession, ImperativeError } from "@zowe/imperative";
+import { AbstractSession, ImperativeError, ImperativeExpect } from "@zowe/imperative";
 
 export class RestartJobs {
 
@@ -66,11 +66,8 @@ export class RestartJobs {
         // Get the job details
         const job: IJob = await GetJobs.getJob(session, jobid);
 
-        if (job.retcode === "CC 0000") {
-            throw new ImperativeError({
-                msg: errorMessagePrefix + "Job status is successful, failed is required"
-            });
-        }
+        ImperativeExpect.toNotBeEqual(job.retcode, "CC 0000",
+                                      errorMessagePrefix + "Job status is successful, failed is required");
 
         // Get the restart job JCL
         const restartJobJcl: string = await this.getRestartJclForJob(session, stepname, job);

--- a/src/api/RestartJobs.ts
+++ b/src/api/RestartJobs.ts
@@ -59,10 +59,18 @@ export class RestartJobs {
     }
 
     public static async restartFailedJob(session: AbstractSession, jobid: string, stepname: string) {
+
+        const errorMessagePrefix: string =
+            `Restarting job with id ${jobid} on ${session.ISession.hostname}:${session.ISession.port} failed: `;
+
         // Get the job details
         const job: IJob = await GetJobs.getJob(session, jobid);
 
-        // TODO: check job status for failed
+        if (job.retcode === "CC 0000") {
+            throw new ImperativeError({
+                msg: errorMessagePrefix + "Job status is successful, failed is required"
+            });
+        }
 
         // Get the restart job JCL
         const restartJobJcl: string = await this.getRestartJclForJob(session, stepname, job);

--- a/src/api/RestartJobs.ts
+++ b/src/api/RestartJobs.ts
@@ -1,0 +1,75 @@
+import { IJob, GetJobs, SubmitJobs } from "@zowe/cli";
+import { AbstractSession, ImperativeError } from "@zowe/imperative";
+
+export class RestartJobs {
+
+    public static async getRestartJclForJob(session: AbstractSession, stepname: string, job: IJob) {
+        const jobJcl: string = await GetJobs.getJclForJob(session, job);
+
+        const newJclLines: string[] = [];
+        let restartParamLine: string = `//             RESTART=(${stepname.toUpperCase()})`;
+        let isStepFound: boolean = false;
+
+        for (const line of jobJcl.split("\n")) {
+            const upperCasedLine = line.toUpperCase();
+
+            // TODO: handle the case where RESTART= param already specified
+
+            // Do not try to process comment lines
+            if (!upperCasedLine.startsWith("//*")) {
+
+                if (upperCasedLine.indexOf("JOB") >= 0) {
+
+                    // Remove redundant `jobid` at the end of JOB statement and odd white spaces
+                    let modifiedJobLine: string = line.replace(job.jobid, "").trim();
+
+                    // Check if JOB statement is multi-line
+                    if (modifiedJobLine.endsWith(",")) {
+                        restartParamLine += ",";
+                    }
+                    else {
+                        modifiedJobLine += ",";
+                    }
+
+                    // Push RESTART= param always on the second line after JOB statement
+                    // This converts JOB statement to multi-line if it was not OR
+                    // just add another line to already multi-lined JOB statement
+                    newJclLines.push(modifiedJobLine);
+                    newJclLines.push(restartParamLine);
+                    continue;
+                }
+
+                // Check if specified step name really exists in JCL
+                if (upperCasedLine.indexOf("EXEC") >= 0 &&
+                        upperCasedLine.startsWith(`//${stepname.toUpperCase()}`)) {
+                    isStepFound = true;
+                }
+            }
+
+            newJclLines.push(line);
+        }
+
+        if (!isStepFound) {
+            throw new ImperativeError({
+                msg: `Step name ${stepname} is not found in a job with jobid ${job.jobid}`
+            });
+        }
+
+        return newJclLines.join("\n");
+    }
+
+    public static async restartFailedJob(session: AbstractSession, jobid: string, stepname: string) {
+        // Get the job details
+        const job: IJob = await GetJobs.getJob(session, jobid);
+
+        // TODO: check job status for failed
+
+        // Get the restart job JCL
+        const restartJobJcl: string = await this.getRestartJclForJob(session, stepname, job);
+
+        // Re-submit restart job JCL
+        // TODO: use additional parms from IRestartParms
+        return SubmitJobs.submitJcl(session, restartJobJcl);
+    }
+
+}

--- a/src/api/doc/input/IRestartParms.ts
+++ b/src/api/doc/input/IRestartParms.ts
@@ -1,0 +1,43 @@
+import { ITaskWithStatus } from "@zowe/imperative";
+
+/**
+ * Interface for restart job API
+ * @export
+ * @interface IRestartParms
+ */
+export interface IRestartParms {
+
+    /**
+     * Returns spool content if this option used
+     */
+    viewAllSpoolContent?: boolean;
+
+    /**
+     * Wait for the job to reach output status
+     */
+    waitForActive?: boolean;
+
+
+    /**
+     * Wait for the job to reach output status
+     */
+    waitForOutput?: boolean;
+
+    /**
+     * Local directory path to download output of the job
+     */
+    directory?: string;
+
+    /**
+     * A file extension to save the job output with
+     */
+    extension?: string;
+
+    /**
+     * Task status object used by CLI handlers to create progress bars
+     * for certain job submit requests
+     * Optional
+     */
+    task?: ITaskWithStatus;
+
+}


### PR DESCRIPTION
Fixes #7 

- Add `RestartJobs` with a set of function to retrive JCL from existing job and re-submit it using `RESTART=(<stepname>)` param included
- Add `IRestartParms` interface to describe additional parameters that might be applied to restart function and control the flow