### PR TITLE
Return default Health Check handler

### DIFF
--- a/__tests__/imperative.test.ts
+++ b/__tests__/imperative.test.ts
@@ -5,6 +5,7 @@ describe("imperative config", () => {
     it("config should match expected values", () => {
         const config = require("../src/imperative");
         expect(config.name).toBe("zos-restart-jobs");
+        expect(config.pluginHealthCheck).toContain("healthCheck.Handler");
         expect(config.pluginSummary).toBe("Zowe CLI restart z/OS jobs plug-in");
         expect(config.productDisplayName).toBe("Zowe CLI z/OS Jobs Restart Plug-in");
         expect(config.rootCommandDescription).toBe("Plugin, which allows to restart z/OS jobs");

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "test:system": "env-cmd __tests__/__resources__/env/system.env jest .*/__system__/.* --coverage false",
     "test:integration": "env-cmd __tests__/__resources__/env/integration.env jest .*/__integration__/.* --coverage false",
     "test:unit": "env-cmd __tests__/__resources__/env/unit.env jest --coverage --testPathIgnorePatterns \".*/__system__|__integration__/.*\"",
-    "install-plugin": "npm i && npm run clean && npm run build && zowe plugins install .",
+    "installPlugin": "npm i && npm run clean && npm run build && zowe plugins install .",
     "exec-plugin": "zowe zos-restart-jobs restart jes",
     "exec-zowe": "zowe"
   },

--- a/src/healthCheck.Handler.ts
+++ b/src/healthCheck.Handler.ts
@@ -1,0 +1,11 @@
+import {ICommandHandler, IHandlerParameters, Logger} from "@zowe/imperative";
+
+export default class HealthCheckHandler implements ICommandHandler {
+  public async process(params: IHandlerParameters): Promise<void> {
+    Logger.getImperativeLogger().debug("Invoked health check handler");
+    params.response.console.log("You would report problems identified by healthCheck.\n" +
+      "This handler is not currently called by Imperative, but\n" +
+      "its existence prevents a warning during plugin validation."
+    );
+  }
+}

--- a/src/imperative.ts
+++ b/src/imperative.ts
@@ -2,6 +2,7 @@ import { IImperativeConfig } from "@zowe/imperative";
 
 const config: IImperativeConfig = {
     commandModuleGlobs: ["**/cli/*/*.definition!(.d).*s"],
+    pluginHealthCheck: __dirname + "/healthCheck.Handler",
     pluginSummary: "Zowe CLI restart z/OS jobs plug-in",
     rootCommandDescription: "Plugin, which allows to restart z/OS jobs",
     productDisplayName: "Zowe CLI z/OS Jobs Restart Plug-in",


### PR DESCRIPTION
Fixes #9 

Should remove warning during plug-in installation.