### PR TITLE
Properly process already specified RESTART= parm

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,10 +78,6 @@ To restart a job with job ID `JOB03456` from step `STEP002`, the following comma
 zowe zos-restart-jobs restart jes JOB03456 STEP002
 ```
 
-## Known issues
-
-- A job that already used `RESTART=` parameter cannot be restarted again ([#11](https://github.com/mr-eshua/zowe-cli-zos-restart-jobs-plugin/issues/11))
-
 ## Software requirements
 
 Before you install and use the plug-in make sure you have installed Zowe CLI on your computer.

--- a/__tests__/api/RestartJobs.test.ts
+++ b/__tests__/api/RestartJobs.test.ts
@@ -76,7 +76,7 @@ describe("RestartJobs tests", () => {
                                    "//STEP02   EXEC PGM=IEFBR14";
 
             const modifiedJobJcl: string = "//TESTJOB JOB (ACCTINFO),'user',CLASS=A,\n" +
-                                           "//             RESTART=(STEP02)\n" +
+                                           "// RESTART=(STEP02)\n" +
                                            "//STEP01   EXEC PGM=XYZ\n" +
                                            "//STEP02   EXEC PGM=IEFBR14";
 
@@ -96,7 +96,111 @@ describe("RestartJobs tests", () => {
                                    "//STEP02   EXEC PGM=IEFBR14";
 
             const modifiedJobJcl: string = "//TESTJOB JOB (ACCTINFO),'user',\n" +
+                                           "//             CLASS=A,\n" +
+                                           "// RESTART=(STEP02)\n" +
+                                           "//STEP01   EXEC PGM=XYZ\n" +
+                                           "//STEP02   EXEC PGM=IEFBR14";
+
+            getJclForJobSpy.mockImplementation(() => jobJcl);
+
+            const resultJobJcl: string = await RestartJobs.getRestartJclForJob(dummySession, stepname, job as IJob);
+
+            expect(getJclForJobSpy).toHaveBeenCalledWith(dummySession, job);
+            expect(resultJobJcl).toEqual(modifiedJobJcl);
+        });
+
+        it("should success with single line JOB statement and RESTART= already specified there", async () => {
+
+            const jobJcl: string = "//TESTJOB JOB (ACCTINFO),'user',RESTART=(STEP01)                       JOB04541\n" +
+                                   "//STEP01   EXEC PGM=XYZ\n" +
+                                   "//STEP02   EXEC PGM=IEFBR14";
+
+            const modifiedJobJcl: string = "//TESTJOB JOB (ACCTINFO),'user',RESTART=(STEP02)\n" +
+                                           "//STEP01   EXEC PGM=XYZ\n" +
+                                           "//STEP02   EXEC PGM=IEFBR14";
+
+            getJclForJobSpy.mockImplementation(() => jobJcl);
+
+            const resultJobJcl: string = await RestartJobs.getRestartJclForJob(dummySession, stepname, job as IJob);
+
+            expect(getJclForJobSpy).toHaveBeenCalledWith(dummySession, job);
+            expect(resultJobJcl).toEqual(modifiedJobJcl);
+        });
+
+        it("should success with multi line JOB statement and RESTART= already specified there", async () => {
+
+            const jobJcl: string = "//TESTJOB JOB (ACCTINFO),'user',RESTART=(STEP01),                      JOB04541\n" +
+                                   "//             CLASS=A\n" +
+                                   "//STEP01   EXEC PGM=XYZ\n" +
+                                   "//STEP02   EXEC PGM=IEFBR14";
+
+            const modifiedJobJcl: string = "//TESTJOB JOB (ACCTINFO),'user',RESTART=(STEP02),\n" +
+                                           "//             CLASS=A\n" +
+                                           "//STEP01   EXEC PGM=XYZ\n" +
+                                           "//STEP02   EXEC PGM=IEFBR14";
+
+            getJclForJobSpy.mockImplementation(() => jobJcl);
+
+            const resultJobJcl: string = await RestartJobs.getRestartJclForJob(dummySession, stepname, job as IJob);
+
+            expect(getJclForJobSpy).toHaveBeenCalledWith(dummySession, job);
+            expect(resultJobJcl).toEqual(modifiedJobJcl);
+        });
+
+        it("should success with multi line JOB statement and RESTART= already specified on other line", async () => {
+
+            const jobJcl: string = "//TESTJOB JOB (ACCTINFO),'user',                                       JOB04541\n" +
+                                   "//             RESTART=(STEP01),\n" +
+                                   "//             CLASS=A\n" +
+                                   "//STEP01   EXEC PGM=XYZ\n" +
+                                   "//STEP02   EXEC PGM=IEFBR14";
+
+            const modifiedJobJcl: string = "//TESTJOB JOB (ACCTINFO),'user',\n" +
                                            "//             RESTART=(STEP02),\n" +
+                                           "//             CLASS=A\n" +
+                                           "//STEP01   EXEC PGM=XYZ\n" +
+                                           "//STEP02   EXEC PGM=IEFBR14";
+
+            getJclForJobSpy.mockImplementation(() => jobJcl);
+
+            const resultJobJcl: string = await RestartJobs.getRestartJclForJob(dummySession, stepname, job as IJob);
+
+            expect(getJclForJobSpy).toHaveBeenCalledWith(dummySession, job);
+            expect(resultJobJcl).toEqual(modifiedJobJcl);
+        });
+
+        it("should success with multi line JOB statement and RESTART= already specified on other line with extra param", async () => {
+
+            const jobJcl: string = "//TESTJOB JOB (ACCTINFO),'user',                                       JOB04541\n" +
+                                   "//             CLASS=A,RESTART=(STEP01),\n" +
+                                   "//             CLASS=A\n" +
+                                   "//STEP01   EXEC PGM=XYZ\n" +
+                                   "//STEP02   EXEC PGM=IEFBR14";
+
+            const modifiedJobJcl: string = "//TESTJOB JOB (ACCTINFO),'user',\n" +
+                                           "//             CLASS=A,RESTART=(STEP02),\n" +
+                                           "//             CLASS=A\n" +
+                                           "//STEP01   EXEC PGM=XYZ\n" +
+                                           "//STEP02   EXEC PGM=IEFBR14";
+
+            getJclForJobSpy.mockImplementation(() => jobJcl);
+
+            const resultJobJcl: string = await RestartJobs.getRestartJclForJob(dummySession, stepname, job as IJob);
+
+            expect(getJclForJobSpy).toHaveBeenCalledWith(dummySession, job);
+            expect(resultJobJcl).toEqual(modifiedJobJcl);
+        });
+
+        it("should success with multi line JOB statement and RESTART= already specified on other line with extra params", async () => {
+
+            const jobJcl: string = "//TESTJOB JOB (ACCTINFO),'user',                                       JOB04541\n" +
+                                   "//             CLASS=A,RESTART=(STEP01),CLASS=A,\n" +
+                                   "//             CLASS=A\n" +
+                                   "//STEP01   EXEC PGM=XYZ\n" +
+                                   "//STEP02   EXEC PGM=IEFBR14";
+
+            const modifiedJobJcl: string = "//TESTJOB JOB (ACCTINFO),'user',\n" +
+                                           "//             CLASS=A,RESTART=(STEP02),CLASS=A,\n" +
                                            "//             CLASS=A\n" +
                                            "//STEP01   EXEC PGM=XYZ\n" +
                                            "//STEP02   EXEC PGM=IEFBR14";


### PR DESCRIPTION
Fixes #11 

- Update restart JCL creation algorithm to respect already specified `RESTART=` parm and to update it for new step name specified
- Add extra unit tests to cover most possible cases with `RESTART=` parm already specified
- Also remove the issue from Known Issues in README